### PR TITLE
configuration helper file

### DIFF
--- a/lib/rspec/rails_rabl.rb
+++ b/lib/rspec/rails_rabl.rb
@@ -1,0 +1,6 @@
+::RSpec.configure do |config|
+  config.include ::RSpec::Rabl::Matchers, :example_group => ->(group,metadata){ group[:file_path].start_with?("./spec/views") }
+  config.include ::RSpec::Rabl::ExampleGroup, :example_group => ->(group,metadata){ group[:file_path].start_with?("./spec/views") }
+  config.rabl_configuration = {:view_paths => ['app/views']}
+  config.extend ::RSpec::Rabl::Helpers
+end


### PR DESCRIPTION
This addresses #2 

Instead of making it a Railtie I just made it a single ruby file that is not automatically included.  So in rails projects you just add a single line the spec_helper.rb file like this:

``` ruby
require 'rspec/rails_rabl'
```

That sets up the configuration that automatically includes the helpers for specs in <code>spec/views/*</code> and extends the helpers for <code>rabl_data</code> <code>rabl_template</code> <code>view_path</code> and <code>rabl_config</code> that goes inside your <code>describe</code> blocks but outside your <code>it</code> blocks.
