### PR TITLE
document the rabl_template helper + spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ describe "budgets/index.rabl" do
 end
 ```
 
+If you don't want to specify the template you are testing via the describe/context string you can specify the template like this:
+
+```ruby
+describe "Users are rendered with the humorous attribute" do
+  rabl_template { "users/show.rabl" }
+  rabl_data(:root => 'user') { user }
+
+  specify { expect(subject).to render_attribute(:humorous).with_value("not really") }
+end
+
 ## Configuration
 
 The easiest way to configure this is simple

--- a/spec/functional/shared_examples_spec.rb
+++ b/spec/functional/shared_examples_spec.rb
@@ -1,0 +1,11 @@
+require 'support/full_name_renderer_examples'
+
+RSpec.describe "using shared examples" do
+  include_context "user_context"
+  rabl_template { "user.rabl" }
+  rabl_data(:root => 'user'){ user }
+
+  include_examples "full name renderer"
+  it_behaves_like "full name renderer"
+  it_should_behave_like "full name renderer"
+end

--- a/spec/support/full_name_renderer_examples.rb
+++ b/spec/support/full_name_renderer_examples.rb
@@ -1,0 +1,4 @@
+shared_examples "full name renderer" do
+  it { should render_attribute(:first_name) }
+  it { should render_attribute(:last_name) }
+end


### PR DESCRIPTION
addresses #11 

@ah the helper for rabl templates already existed, but wasn't documented in the README. I wrote a functional spec that covers the cases we discussed in the issue and I added an example to the README.

What do you think?