### PR TITLE
Improve matcher error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ rvm:
   - 2.1
   - 2.2
   - jruby
+  - jruby-1.7
+  - jruby-9.0.3.0
   - jruby-head
+before_install:
+  - gem update --system
+  - gem install bundler
 sudo: false
 cache: bundler

--- a/lib/rspec/rabl/attribute_matcher.rb
+++ b/lib/rspec/rabl/attribute_matcher.rb
@@ -11,7 +11,7 @@ module RSpec
       end
 
       def failure_message
-        "expected #{parsed} to render #{rendered_attribute} = #{expected_value}"
+        "expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}"
       end
 
       def matches?(subject)
@@ -32,6 +32,15 @@ module RSpec
       private
       attr_reader :rendered_attribute, :subject, :opts
 
+      def attribute_path
+        @attribute_path ||= begin
+          path = ""
+          path << "[\"#{opts[:root]}\"]" if opts[:root]
+          path << "[\"#{opts[:object_root]}\"]" if opts[:object_root]
+          path << "[\"#{rendered_attribute}\"]"
+        end
+      end
+
       def model_attribute
         @model_attribute ||= rendered_attribute
       end
@@ -49,7 +58,7 @@ module RSpec
       end
 
       def attribute_rendered?
-        parsed_object.has_key?(rendered_attribute.to_s)
+        parsed_object.key?(rendered_attribute.to_s)
       end
 
       def get_attribute_from_rendered_object

--- a/spec/functional/matcher_errors_spec.rb
+++ b/spec/functional/matcher_errors_spec.rb
@@ -1,0 +1,45 @@
+describe "Error Messages" do
+  it "renders a helpful error message without root or object_root options" do
+    example = nil
+    group = RSpec.describe "user.rabl" do
+      include_context "user_context"
+      example = it{ expect(subject).to render_attribute(:guid).with_value("Imma derp derp") }
+    end
+    group.run
+    lines = RSpec::Core::Notifications::FailedExampleNotification.new(example).message_lines
+
+    expect(lines[0]).to include("with_value(\"Imma derp derp\")")
+    expect(lines[1]).to include("  expected \"Imma derp derp\" in [\"guid\"]")
+    expect(lines[2]).to include("    got nil")
+  end
+
+  it "renders a helpful error message for root and object_root" do
+    example = nil
+    group = RSpec.describe "user.rabl" do
+      include_context "user_context"
+      rabl_data(:object_root => "user"){ [user] }
+      example = it{ expect(subject).to render_attribute(:guid).with_value("Imma derp derp") }
+    end
+    group.run
+    lines = RSpec::Core::Notifications::FailedExampleNotification.new(example).message_lines
+
+    expect(lines[0]).to include("with_value(\"Imma derp derp\")")
+    expect(lines[1]).to include("  expected \"Imma derp derp\" in [\"user\"][\"guid\"]")
+    expect(lines[2]).to include("    got \"abc\"")
+  end
+
+  it "renders a helpful error message for root and object_root" do
+    example = nil
+    group = RSpec.describe "index.rabl" do
+      include_context "user_context"
+      rabl_data(:root => "users", :object_root => "user"){ [user] }
+      example = it{ expect(subject).to render_attribute(:guid).with_value("Imma derp derp") }
+    end
+    group.run
+    lines = RSpec::Core::Notifications::FailedExampleNotification.new(example).message_lines
+
+    expect(lines[0]).to include("with_value(\"Imma derp derp\")")
+    expect(lines[1]).to include("  expected \"Imma derp derp\" in [\"users\"][\"user\"][\"guid\"]")
+    expect(lines[2]).to include("    got \"abc\"")
+  end
+end


### PR DESCRIPTION
This improves the matcher error messages by generating an attribute
path that we can use to show where we are checking for the expected
value as well as the actual value.

Issue: https://github.com/mmmries/rspec_rabl/issues/12

Example:
```ruby
describe "user.rabl" do
  rabl_data(:root => "users", :object_root => "user") { [user] }
  it { expect(subject).to render_attribute(:guid).with_value("G-123") }
end
```
Could generate the following error:
```
1) Customer Matchers user.rabl should render the guid attribute
   Failure/Error: it{ expect(subject).to render_attribute(:guid).with_value("G-123") }
     expected "G-123" in ["users"]["user"]["guid"]
       got nil
```

For the [tshirt](https://hacktoberfest.digitalocean.com) (:tshirt:)!!

cc @mmmries @liveh2o