### PR TITLE
Rbj/fix expected value setter

### DIFF
--- a/lib/rspec/rabl/attribute_matcher.rb
+++ b/lib/rspec/rabl/attribute_matcher.rb
@@ -16,7 +16,7 @@ module RSpec
 
       def matches?(subject)
         @subject = subject
-        attribute_rendered? && rendered_value == expected_value
+        attribute_rendered? && (!expected_value_set || rendered_value == expected_value)
       end
 
       def with(model_attribute)
@@ -25,12 +25,13 @@ module RSpec
       end
 
       def with_value(expected_value)
+        @expected_value_set = true
         @expected_value = expected_value
         self
       end
 
       private
-      attr_reader :rendered_attribute, :subject, :opts
+      attr_reader :rendered_attribute, :subject, :opts, :expected_value_set
 
       def attribute_path
         @attribute_path ||= begin
@@ -45,8 +46,10 @@ module RSpec
         @model_attribute ||= rendered_attribute
       end
 
+      # The expected value may be set to nil or false. Retrieving the value from the rendered object
+      # will then fail if the attribute is calculated from a node
       def expected_value
-        @expected_value ||= @expected_value.nil? ? get_attribute_from_rendered_object : @expected_value
+        @expected_value ||= @expected_value_set ? @expected_value : get_attribute_from_rendered_object
       end
 
       def rendered_value

--- a/lib/rspec/rabl/attribute_matcher.rb
+++ b/lib/rspec/rabl/attribute_matcher.rb
@@ -46,7 +46,7 @@ module RSpec
       end
 
       def expected_value
-        @expected_value ||= get_attribute_from_rendered_object
+        @expected_value ||= @expected_value.nil? ? get_attribute_from_rendered_object : @expected_value
       end
 
       def rendered_value

--- a/spec/fixtures/user_aliases.rabl
+++ b/spec/fixtures/user_aliases.rabl
@@ -1,3 +1,4 @@
 object @user => :user
 attributes  :guid => :id
 node(:team){ 'Gorby Puff' }
+node(:feed_is_deleted) { |user| user.is_deleted }

--- a/spec/fixtures/user_aliases.rabl
+++ b/spec/fixtures/user_aliases.rabl
@@ -2,3 +2,4 @@ object @user => :user
 attributes  :guid => :id
 node(:team){ 'Gorby Puff' }
 node(:feed_is_deleted) { |user| user.is_deleted }
+node(:i_am_nil) { |user| user.nil_value }

--- a/spec/functional/custom_matchers_spec.rb
+++ b/spec/functional/custom_matchers_spec.rb
@@ -15,6 +15,7 @@ describe "Customer Matchers" do
     it{ expect(subject).to render_attribute(:id).with(:guid) }
     it{ expect(subject).to render_attribute(:team).with_value('Gorby Puff') }
     it{ expect(subject).to render_attribute(:feed_is_deleted).with_value(false) }
+    it{ expect(subject).to render_attribute(:i_am_nil).with_value(nil) }
   end
 
   describe "index.rabl" do

--- a/spec/functional/custom_matchers_spec.rb
+++ b/spec/functional/custom_matchers_spec.rb
@@ -14,6 +14,7 @@ describe "Customer Matchers" do
     rabl_data(:root => 'user'){ user }
     it{ expect(subject).to render_attribute(:id).with(:guid) }
     it{ expect(subject).to render_attribute(:team).with_value('Gorby Puff') }
+    it{ expect(subject).to render_attribute(:feed_is_deleted).with_value(false) }
   end
 
   describe "index.rabl" do

--- a/spec/support/user_context.rb
+++ b/spec/support/user_context.rb
@@ -5,6 +5,7 @@ shared_context "user_context" do
     last_name: 'bluth',
     email: 'gob@bluth.com',
     password: 'very secret',
-    is_deleted: false
+    is_deleted: false,
+    nil_value: nil,
   )}
 end

--- a/spec/support/user_context.rb
+++ b/spec/support/user_context.rb
@@ -5,5 +5,6 @@ shared_context "user_context" do
     last_name: 'bluth',
     email: 'gob@bluth.com',
     password: 'very secret',
+    is_deleted: false
   )}
 end


### PR DESCRIPTION
There is a bug with `with_value` where if the user expected a `false` or `nil` value the lazy setter was ignoring that it had already been set.  This becomes problematic when the expected value is derived from a node that is not on the `rendered_obect`.

This adds a flag, `expected_value_set`, that tracks if `expected_value` has been explicitly set.  If so, we will render that `expected_value`, otherwise, it will pull the value from the `rendered_object`

@mmmries @film42 @liveh20 @abrandoned