### PR TITLE
Implement a nil value check in the attribute matcher

### DIFF
--- a/lib/rspec/rabl/attribute_matcher.rb
+++ b/lib/rspec/rabl/attribute_matcher.rb
@@ -11,7 +11,7 @@ module RSpec
       end
 
       def failure_message
-        if nil_value?
+        if implicit_nil_value?
           "nil value when testing.\n expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}\n If you want to test for a nil value, please use `with_value(nil)`"
         else
           "expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}"
@@ -20,16 +20,12 @@ module RSpec
 
       def matches?(subject)
         @subject = subject
-        attribute_rendered? && (!expected_value_set || rendered_value == expected_value) && nil_value_check?
+        attribute_rendered? && (!expected_value_set || rendered_value == expected_value) && !implicit_nil_value?
       end
 
-      def nil_value?
+      def implicit_nil_value?
+        return false if expected_value_set
         rendered_value.nil? || expected_value.nil?
-      end
-
-      def nil_value_check?
-        return true if expected_value_set
-        !nil_value?
       end
 
       def with(model_attribute)

--- a/lib/rspec/rabl/attribute_matcher.rb
+++ b/lib/rspec/rabl/attribute_matcher.rb
@@ -11,12 +11,25 @@ module RSpec
       end
 
       def failure_message
-        "expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}"
+        if nil_value?
+          "nil value when testing.\n expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}\n If you want to test for a nil value, please use `with_value(nil)`"
+        else
+          "expected #{expected_value.inspect} in #{attribute_path}\n  got #{rendered_value.inspect}"
+        end
       end
 
       def matches?(subject)
         @subject = subject
-        attribute_rendered? && (!expected_value_set || rendered_value == expected_value)
+        attribute_rendered? && (!expected_value_set || rendered_value == expected_value) && nil_value_check?
+      end
+
+      def nil_value?
+        rendered_value.nil? || expected_value.nil?
+      end
+
+      def nil_value_check?
+        return true if expected_value_set
+        !nil_value?
       end
 
       def with(model_attribute)

--- a/spec/functional/matcher_errors_spec.rb
+++ b/spec/functional/matcher_errors_spec.rb
@@ -45,4 +45,23 @@ describe "Error Messages" do
     expect(lines).to include("  expected \"Imma derp derp\" in [\"users\"][\"user\"][\"guid\"]")
     expect(lines).to include("    got \"abc\"")
   end
+
+  it "renders a helpful error message for nil tests" do
+    example = nil
+    group = RSpec.describe "index.rabl" do
+      include_context "user_context"
+      rabl_data(:root => "users", :object_root => "user"){ [user] }
+      example = it "tries to render nil attribute" do 
+        allow(user).to receive(:foo).and_return(nil)
+        expect(subject).to render_attribute(:foo)
+      end
+    end
+    group.run
+    lines = RSpec::Core::Notifications::FailedExampleNotification.new(example).message_lines.join("\n")
+
+    expect(lines).to include("nil value when testing.")
+    expect(lines).to include("  expected nil in [\"users\"][\"user\"][\"foo\"]")
+    expect(lines).to include("  got nil")
+    expect(lines).to include("  If you want to test for a nil value, please use `with_value(nil)`")
+  end
 end


### PR DESCRIPTION
When testing some view specs, there would be false positives from expecting a nil value and rendering a nil value. I believe that these are not correct tests to write, and that when testing nil rspec_rabl should fail that test and alert that user.

@mmmries @film42 