### PR TITLE
`rabl_config` now supports specifying the renderer's scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.2.2
   - ruby-head
+  - jruby-9.0.4.0
   - jruby-head
 before_install:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 rvm:
-  - 1.9
-  - 2.0
-  - 2.1
-  - 2.2
-  - jruby-1.7
-  - jruby-9.0.4.0
+  - 2.2.2
+  - ruby-head
+  - jruby-head
 before_install:
   - gem update --system
   - gem install bundler -v 1.10.6

--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ require 'rspec/rabl/rails'
 
 For more detailed configuration just look at that file to see what configurations it is making.
 
+Additionally, there are two config attributes which can be specified using `rabl_config`:
+
+`scope` is the rendering context which is passed to create the underlying Rabl::Renderer instance for an example group. If your rabl template is using, for example, view helpers in Rails but your spec is raising a `NoMethodError`, then you probably want to pass in a scope which includes that helper.
+
+```ruby
+describe "Users which use a Helper to transform data for presentation" do
+  class ScopeWithUsersHelper
+    include Singleton
+    include UsersHelper # could have a method which formats an email address for use below
+  end
+
+  rabl_config(:scope => ScopeWithUsersHelper.instance)
+  rabl_template { "users/show.rabl" }
+  rabl_data(:root => 'user') { user }
+
+  specify { expect(subject).to render_attribute(:formatted_email).with_value('"Kung Fury" <thechosenone@example.com>') }
+end
+```
+
+`view_paths` instructs the Rabl::Renderer where to look for its rabl templates for the purpose of an example group.
+
 ## Contributing
 
 1. Fork it

--- a/lib/rspec/rabl/example_group.rb
+++ b/lib/rspec/rabl/example_group.rb
@@ -14,6 +14,7 @@ module RSpec
           _rabl_template.gsub('.rabl',''),
           _rabl_data,
           :view_path => _rabl_config[:view_paths],
+          :scope     => _rabl_config[:scope],
         )
       end
 

--- a/spec/fixtures/user_renderer_scope.rabl
+++ b/spec/fixtures/user_renderer_scope.rabl
@@ -1,0 +1,5 @@
+object @user => :user
+attributes  :guid => :id
+node(:full_name){ |user| full_name(user) }
+node(:formatted_email){ |user| formatted_email(full_name(user), user.email) }
+node(:password){ |user| hide_password(user.password) }

--- a/spec/functional/renderer_scope_spec.rb
+++ b/spec/functional/renderer_scope_spec.rb
@@ -1,0 +1,21 @@
+describe "Renderer Scope" do
+  include_context "user_context"
+
+  describe "user_renderer_scope.rabl" do
+    rabl_data(:root => 'user'){ user }
+    rabl_config(scope: RendererScopeHelper)
+
+    it{ expect(subject).to render_attribute(:full_name).with_value('gob bluth') }
+    it{ expect(subject).to render_attribute(:formatted_email).with_value('"gob bluth" <gob@bluth.com>') }
+    it{ expect(subject).to render_attribute(:password).with_value('***********') }
+  end
+
+  describe "user_renderer_scope.rabl (without scope supplied)" do
+    rabl_data(:root => 'user'){ user }
+    rabl_template { "user_renderer_scope.rabl" }
+
+    it "should fail if not configured with an appropriate scope" do
+      expect{ rendered_template  }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec'
 require 'rspec/rabl'
 
 require 'support/user_context'
+require 'support/renderer_scope_helper'
 
 RSpec.configure do |c|
   c.order = :rand

--- a/spec/support/renderer_scope_helper.rb
+++ b/spec/support/renderer_scope_helper.rb
@@ -1,0 +1,13 @@
+class RendererScopeHelper
+  def self.full_name(user)
+    [user.first_name, user.last_name].join(" ")
+  end
+
+  def self.formatted_email(name, email)
+    "\"#{name}\" <#{email}>"
+  end
+
+  def self.hide_password(password)
+    "*" * password.length
+  end
+end


### PR DESCRIPTION
Adding ability to specify Rabl::Renderer scope for an example group to, for example, allow Rails view helpers to be called from rabl templates within a spec